### PR TITLE
从最新plugin项目吸收core逻辑，准备让plugin项目真实复用

### DIFF
--- a/src/main/kotlin/whiter/music/mider/code/MiderCodeParser.kt
+++ b/src/main/kotlin/whiter/music/mider/code/MiderCodeParser.kt
@@ -443,6 +443,8 @@ class MacroConfiguration(build: MacroConfigurationBuilder.() -> Unit = {}) {
         val ifNotDefinePattern = Regex("if!def\\s+([a-zA-Z_]\\w*)\\s+[^>]+")
         val repeatPattern = Regex("repeat\\s+(\\d+)\\s*:\\s*[^>]+")
         val includePattern = Regex("include\\s+((https?|ftp|file)://)?[-A-Za-z0-9+&@#/%?=~_|!:,.;]+[-A-Za-z0-9+&@#/%=~_|]")
+        val commentPattern = Regex("#\\s+[\\s\\S]+")
+        val velocityPattern = Regex("velocity\\s+(linear\\s|func\\s)(\\d{1,3}\\s*~\\s*\\d{1,3})\\s*:\\s*[^>]+")
     }
 
     var recursionCount = 0 // 递归次数统计
@@ -494,7 +496,7 @@ class MacroConfiguration(build: MacroConfigurationBuilder.() -> Unit = {}) {
 }
 
 class MiderCodeParserConfiguration(build: Builder.() -> Unit = {}) {
-
+    var formatMode: String = "internal->java-lame"
     var _isBlankReplaceWith0 = false
     var macroConfiguration = MacroConfiguration()
 

--- a/src/main/kotlin/whiter/music/mider/code/MidiProduceCore.kt
+++ b/src/main/kotlin/whiter/music/mider/code/MidiProduceCore.kt
@@ -9,36 +9,88 @@ import javax.sound.midi.Sequencer
 import kotlin.concurrent.timerTask
 import kotlin.contracts.ExperimentalContracts
 
-@ExperimentalContracts
-fun miderCodeToMiderDSL(msg: String, config: MiderCodeParserConfiguration = MiderCodeParserConfiguration()): MiderDSL {
+val startRegex = Regex(">(g|f|\\d+b)((;[-+b#]?[A-G](min|maj|major|minor)?)|(;\\d)|(;img)|(;pdf)|(;mscz)|(;midi)|(;i=[a-zA-Z-]+)|(;\\d/\\d))*>")
 
-    val startRegex = Regex(">(g|f|\\d+b)((;[-+b#]?[A-G](min|maj|major|minor)?)|(;\\d)|(;vex|vex&au)|(;midi))*>")
-    // val cmdRegex = Regex("${startRegex.pattern}[\\S\\s]+")
+enum class NotationType {
+    PNGS, MSCZ, PDF
+}
+
+data class ProduceCoreResult(
+    var miderDSL: MiderDSL = MiderDSL(),
+    var isRenderingNotation: Boolean = false,
+    var isUploadMidi: Boolean = false,
+    var notationType: NotationType? = null,
+    val logs: MutableList<String> = ArrayList()
+)
+
+
+@ExperimentalContracts
+fun produceCore(msg: String, config: MiderCodeParserConfiguration = MiderCodeParserConfiguration()): ProduceCoreResult {
 
     val noteLists = msg.split(startRegex).toMutableList()
     noteLists.removeFirst()
     val configParts = startRegex.findAll(msg).map { it.value.replace(">", "") }.toList()
 
-    val dslBlock: MiderDSL.() -> Unit = {
-        val changeBpm = { tempo: Int -> bpm = tempo }
+    /*
+     * 在这个块中，ProduceCoreResult的各个成员被修改，所以是ProduceCoreResult的拓展函数
+     */
+    val build: ProduceCoreResult.() -> Unit = {
+        val changeBpm = { tempo: Int -> miderDSL.bpm = tempo }
+        val changeOuterProgram = { ins: String -> miderDSL.program = MiderDSL.instrument.valueOf(ins) }
+        val changeTimeSignature = { pair: Pair<Int, Int> -> miderDSL.timeSignature = pair }
+        // todo 怪, 应该每条轨道都能设置才对
 
         noteLists.forEachIndexed { index, content ->
-            track {
+            miderDSL.track {
                 var mode = ""
                 var defaultPitch = 4
                 defaultNoteDuration = 1
 
                 configParts[index].split(";").forEach {
-                    if (it == "f") {
-                        defaultPitch = 3
-                    } else if (it.matches(Regex("\\d+b"))) {
-                        changeBpm(it.replace("b", "").toInt())
-                    } else if (it.matches(Regex("[-+b#]?[A-G](min|maj|major|minor)?"))) {
-                        mode = it
-                    } else if (it.matches(Regex("\\d"))) {
-                        defaultPitch = it.toInt()
-                    } else if (it.matches(Regex("vex|wex&au"))) {
+                    when (it) {
 
+                        "g" -> defaultPitch = 4 // 这样应该能提升性能吧(
+
+                        "f" -> defaultPitch = 3
+
+                        "midi" -> isUploadMidi = true
+
+                        "img" -> {
+                            isRenderingNotation = true
+                            notationType = NotationType.PNGS
+                        }
+
+                        "pdf" -> {
+                            isRenderingNotation = true
+                            notationType = NotationType.PDF
+                        }
+
+                        "mscz" -> {
+                            isRenderingNotation = true
+                            notationType = NotationType.MSCZ
+                        }
+
+                        else -> {
+                            if (it.matches(Regex("\\d+b"))) {
+                                changeBpm(it.replace("b", "").toInt())
+                            } else if (it.matches(Regex("[-+b#]?[A-G](min|maj|major|minor)?"))) {
+                                mode = it
+                            } else if (it.matches(Regex("\\d"))) {
+                                defaultPitch = it.toInt()
+                            } else if (it.matches(Regex("\\d/\\d"))) {
+                                val ts = it.split("/")
+                                changeTimeSignature(ts[0].toInt() to ts[1].toInt())
+                            } else if (it.matches(Regex("i=[a-zA-Z-]+"))) {
+                                // 两个都设置下 (
+                                program = MiderDSL.instrument.valueOf(it.replace("i=", ""))
+                                // todo fix
+                                if (!config.formatMode.contains("muse-score")) {
+                                    changeOuterProgram(it.replace("i=", ""))
+                                    logs.add("set outer program to $program")
+                                }
+                                logs.add("set program to $program")
+                            }
+                        }
                     }
                 }
 
@@ -48,7 +100,10 @@ fun miderCodeToMiderDSL(msg: String, config: MiderCodeParserConfiguration = Mide
                     Regex("[c-gaA-G]").find(sequence) != null || Regex("(\\s*b\\s*)+").matches(sequence)
 
                 val rendered = toInMusicScoreList(
-                    sequence,
+                    sequence.let {
+                        if (isStave && config._isBlankReplaceWith0) it else
+                            it.trim().replace(Regex("( {2}| \\| )"), "0")
+                    },
                     isStave = isStave,
                     pitch = defaultPitch, useMacro = false
                 )
@@ -57,13 +112,15 @@ fun miderCodeToMiderDSL(msg: String, config: MiderCodeParserConfiguration = Mide
                     val stander = toMiderStanderNoteString(rendered)
                     if (stander.isNotBlank()) !stander
                 }
+
+                logs.add("track: ${index + 1}")
             }
         }
     }
 
-    val dsl = MiderDSL()
-    dsl.dslBlock()
-    return dsl
+    val result = ProduceCoreResult()
+    result.build()
+    return result
 }
 
 private fun MiderDSL.ifUseMode(mode: String, block: MiderDSL.()-> Unit) {

--- a/src/test/kotlin/MiderCodeParserTest.kt
+++ b/src/test/kotlin/MiderCodeParserTest.kt
@@ -1,10 +1,11 @@
 import whiter.music.mider.code.MiderCodeParserConfiguration
-import whiter.music.mider.code.miderCodeToMiderDSL
+import whiter.music.mider.code.produceCore
 import whiter.music.mider.dsl.playDslInstance
 import kotlin.contracts.ExperimentalContracts
 
 @ExperimentalContracts
 fun main(args: Array<String>) {
-    val miderDSL = miderCodeToMiderDSL(">g>A#F-G-A#F-G-A-a-^#C-D-^#F-G- #FD-E-#F #f-g-^^vv^#f-g-^ gb-vg#f-e-#f-e-d-e-#f-g-^^ gb-v b#C-D- a-^#C-D-^#F-G-^")
-    playDslInstance(miderDSL = miderDSL)
+    val result = produceCore(">g>A#F-G-A#F-G-A-a-^#C-D-^#F-G- #FD-E-#F #f-g-^^vv^#f-g-^ gb-vg#f-e-#f-e-d-e-#f-g-^^ gb-v b#C-D- a-^#C-D-^#F-G-^")
+    result.logs.forEach{ println(it) }
+    playDslInstance(miderDSL = result.miderDSL)
 }

--- a/src/test/kotlin/test2.kt
+++ b/src/test/kotlin/test2.kt
@@ -1,4 +1,3 @@
-import whiter.music.mider.code.miderCodeToMiderDSL
 import whiter.music.mider.dsl.play
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
1. 鉴于miderCode不光含有miderDSL的信息，还含有NotationType等信息，故打包成ProduceCoreResult，作为miderCode处理的所有结果的集合，顺便还能把logs带出来。
2. 准备pr plugin项目，改为调用MidiProduceCore.produceCore()的方式真实复用。